### PR TITLE
Add IntelliJ IDEA support to the build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 /.gradle/
+/*.iml
+/*.ipr
+/*.iws
+/*/*.iml

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ buildscript {
 def p = project
 
 allprojects {
+    apply plugin: 'idea'
     apply plugin: 'org.ajoberstar.release-opinion'
 
     group = 'com.login-box'


### PR DESCRIPTION
I'd like not to have to have IDE-specific glue in the build script, but Gradle
doesn't provide a good way to inject plugins from the CLI.