### PR TITLE
Compute the version once (in the root project).

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,17 +10,17 @@ buildscript {
     }
 }
 
-def p = project
+apply plugin: 'org.ajoberstar.release-opinion'
+
+release {
+    grgit = Grgit.open(projectDir)
+}
 
 allprojects {
     apply plugin: 'idea'
-    apply plugin: 'org.ajoberstar.release-opinion'
 
     group = 'com.login-box'
-
-    release {
-        grgit = Grgit.open(p.projectDir)
-    }
+    version = rootProject.version
 
     repositories {
         mavenCentral()


### PR DESCRIPTION
This causes fewer round-trips to Git, and reduces output spam from the release
plugin. Net win!