### PR TITLE
Assemble source JARs for each JAR.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -43,12 +43,18 @@ subprojects {
 
     sourceCompatibility = '1.8'
 
+    task sourcesJar(type: Jar, dependsOn: classes) {
+        classifier = 'sources'
+        from sourceSets.main.allSource
+    }
+
     task javadocJar(type: Jar, dependsOn: javadoc) {
         classifier = 'javadoc'
         from javadoc.destinationDir
     }
 
     artifacts {
+        archives sourcesJar
         archives javadocJar
     }
 }


### PR DESCRIPTION
This is required for Bintray, and helps with things like IDE navigation and
debugging.