### PR TITLE
Compile during the dependencies phase.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,6 +3,11 @@ machine:
     java:
         version: oraclejdk8
 
+dependencies:
+    override:
+        - ./gradlew classes
+        - ./gradlew testClasses
+
 test:
     post:
         - ./gradlew javadoc


### PR DESCRIPTION
This should (a) reduce the amount of time spent "in" tests, and (b) shake out
compile errors earlier.