### PR TITLE
Wait longer to find out what port number test child processes report.

### DIFF
--- a/dropwizard-heroku-http/src/test/java/com/loginbox/heroku/http/HerokuConnectorFactoryTest.java
+++ b/dropwizard-heroku-http/src/test/java/com/loginbox/heroku/http/HerokuConnectorFactoryTest.java
@@ -49,7 +49,8 @@ class ConnectorFactoryPortHarness {
                 .redirectOutput(ProcessBuilder.Redirect.PIPE);
 
         Process process = pb.start();
-        if (process.waitFor(1, TimeUnit.SECONDS))
+        /* Shockingly long, but sometimes CircleCI bogs down. */
+        if (process.waitFor(5, TimeUnit.SECONDS))
             // default platform encoding is actually correct here, shockingly.
             try (InputStreamReader r = new InputStreamReader(process.getInputStream())) {
                 String output = CharStreams.toString(r).trim();


### PR DESCRIPTION
Speculative fix. CircleCI is failing these tests, and I suspect it's just load.