### PR TITLE
Allow URLs with no credentials.

### DIFF
--- a/dropwizard-heroku-db/src/main/java/com/loginbox/heroku/db/HerokuDataSourceFactory.java
+++ b/dropwizard-heroku-db/src/main/java/com/loginbox/heroku/db/HerokuDataSourceFactory.java
@@ -67,6 +67,8 @@ public class HerokuDataSourceFactory extends DataSourceFactory {
 
     private void applyCredentials(URI databaseUri) {
         String userInfo = databaseUri.getUserInfo();
+        if (userInfo == null)
+            return;
         String[] userInfoParts = userInfo.split(Pattern.quote(":"), 2);
 
         if (userInfoParts.length >= 1)

--- a/dropwizard-heroku-db/src/test/java/com/loginbox/heroku/db/HerokuDataSourceFactoryTest.java
+++ b/dropwizard-heroku-db/src/test/java/com/loginbox/heroku/db/HerokuDataSourceFactoryTest.java
@@ -23,6 +23,18 @@ public class HerokuDataSourceFactoryTest {
     }
 
     @Test
+    public void permitsMissingCredentials() throws IOException, InterruptedException {
+        HerokuDataSourceFactory f = run(
+                HerokuDataSourceFactory.class,
+                set("DATABASE_URL", "postgres://db.example.com/database")
+        );
+        assertThat(f.getDriverClass(), is("org.postgresql.Driver"));
+        assertThat(f.getUrl(), is("jdbc:postgresql://db.example.com/database"));
+        assertThat(f.getUser(), is(nullValue()));
+        assertThat(f.getPassword(), is(""));
+    }
+
+    @Test
     public void noEnvironmentNoConfig() throws IOException, InterruptedException {
         HerokuDataSourceFactory f = run(
                 HerokuDataSourceFactory.class,


### PR DESCRIPTION
These are useful when testing: for example, Postgres.app permits (local) TCP/IP
logins with no username.