### PR TITLE
Disable request logging.

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,6 @@ re/apidocs/io/dropwizard/server/SimpleServerFactory.html), and behaves much the
 same way. Both the application context (at `/`) and the admin context (at
 `/!/admin/`) are served on the same listener. The port _automatically_ defaults
 to `$PORT`, if set, or to `5000` otherwise.
+
+This also disables Dropwizard's default request logging. Heroku's routing stack
+logs the same information.

--- a/dropwizard-heroku-http/src/main/java/com/loginbox/heroku/http/HerokuRequestLogFactory.java
+++ b/dropwizard-heroku-http/src/main/java/com/loginbox/heroku/http/HerokuRequestLogFactory.java
@@ -1,0 +1,17 @@
+package com.loginbox.heroku.http;
+
+import com.google.common.collect.ImmutableList;
+import io.dropwizard.jetty.RequestLogFactory;
+
+/**
+ * Default request logging behaviour on Heroku: log nothing. This defaults to an empty list of appenders, rather than
+ * defaulting to appending to standard output.
+ *
+ * @see com.loginbox.heroku.http.HerokuServerFactory
+ * @see io.dropwizard.jetty.RequestLogFactory
+ */
+public class HerokuRequestLogFactory extends RequestLogFactory {
+    {
+        setAppenders(ImmutableList.of());
+    }
+}

--- a/dropwizard-heroku-http/src/main/java/com/loginbox/heroku/http/HerokuServerFactory.java
+++ b/dropwizard-heroku-http/src/main/java/com/loginbox/heroku/http/HerokuServerFactory.java
@@ -67,5 +67,6 @@ public class HerokuServerFactory extends SimpleServerFactory {
         setConnector(new HerokuConnectorFactory());
         setApplicationContextPath(APP_CONTEXT_PATH);
         setAdminContextPath(ADMIN_CONTEXT_PATH);
+        setRequestLogFactory(new HerokuRequestLogFactory());
     }
 }

--- a/dropwizard-heroku-http/src/test/java/com/loginbox/heroku/http/HerokuRequestLogFactoryTest.java
+++ b/dropwizard-heroku-http/src/test/java/com/loginbox/heroku/http/HerokuRequestLogFactoryTest.java
@@ -1,0 +1,16 @@
+package com.loginbox.heroku.http;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+
+public class HerokuRequestLogFactoryTest {
+    private final HerokuRequestLogFactory factory = new HerokuRequestLogFactory();
+
+    @Test
+    public void noAppenders() {
+        assertThat(factory.getAppenders(), is(empty()));
+    }
+}

--- a/dropwizard-heroku-http/src/test/java/com/loginbox/heroku/http/HerokuServerFactoryTest.java
+++ b/dropwizard-heroku-http/src/test/java/com/loginbox/heroku/http/HerokuServerFactoryTest.java
@@ -19,4 +19,9 @@ public class HerokuServerFactoryTest {
         assertThat(factory.getApplicationContextPath(), is("/"));
         assertThat(factory.getAdminContextPath(), is("/!/admin/"));
     }
+
+    @Test
+    public void configuresLogging() {
+        assertThat(factory.getRequestLogFactory(), is(instanceOf(HerokuRequestLogFactory.class)));
+    }
 }


### PR DESCRIPTION
Heroku handles it in their router, and this duplication is ugly:

    2015-03-22T05:11:19.681878+00:00 heroku[router]: at=info method=GET path="/" host=login-box-owen.herokuapp.com request_id=09c32c7c-6131-40ce-823d-60e9e29af074 fwd="23.91.157.215" dyno=web.1 connect=1ms service=81ms status=303 bytes=137
    2015-03-22T05:11:19.673684+00:00 app[web.1]: 23.91.157.215 - - [22/Mar/2015:05:11:19 +0000] "GET / HTTP/1.1" 303 - "-" "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_2) AppleWebKit/600.4.10 (KHTML, like Gecko) Version/8.0.4 Safari/600.4.10" 76