### PR TITLE
Fix warnings about trailing slashes in context paths.

### DIFF
--- a/dropwizard-heroku-http/src/main/java/com/loginbox/heroku/http/HerokuServerFactory.java
+++ b/dropwizard-heroku-http/src/main/java/com/loginbox/heroku/http/HerokuServerFactory.java
@@ -61,7 +61,7 @@ public class HerokuServerFactory extends SimpleServerFactory {
     /**
      * The default root path for the Dropwizard admin application, when served out of this server factory.
      */
-    public static final String ADMIN_CONTEXT_PATH = RESERVED_PREFIX + "admin/";
+    public static final String ADMIN_CONTEXT_PATH = RESERVED_PREFIX + "admin";
 
     {
         setConnector(new HerokuConnectorFactory());

--- a/dropwizard-heroku-http/src/test/java/com/loginbox/heroku/http/HerokuServerFactoryTest.java
+++ b/dropwizard-heroku-http/src/test/java/com/loginbox/heroku/http/HerokuServerFactoryTest.java
@@ -17,7 +17,7 @@ public class HerokuServerFactoryTest {
     @Test
     public void configuresContextPaths() {
         assertThat(factory.getApplicationContextPath(), is("/"));
-        assertThat(factory.getAdminContextPath(), is("/!/admin/"));
+        assertThat(factory.getAdminContextPath(), is("/!/admin"));
     }
 
     @Test


### PR DESCRIPTION
Harmless, but annoying:

    WARN  org.eclipse.jetty.server.handler.ContextHandler: i.d.j.MutableServletContextHandler@5d5d9e5{/,null,null} contextPath ends with /