### PR TITLE
Pass URL parameters from `DATABASE_URL` through to JDBC.

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,17 @@ public class ExampleConfiguration extends Configuration {
 The resulting configuration can be used with Dropwizard's usual database access
 layers.
 
+In addition to supporting Heroku's `DATABASE_URL` convention, this module also
+supports passing URL parameters through to the PostgreSQL JDBC driver. This can,
+for example, be used to access a Heroku database from outside of Heroku, by
+adding [Heroku's recommended SSL configuration](https://devcenter.heroku.com/articles/connecting-to-relational-databases-on-heroku-with-java#connecting-to-a-database-remotely)
+to `DATABASE_URL`:
+
+```
+DATABASE_URL=postgres://demo@db.example.com/hello-world?ssl=true&sslfactory=org.postgresql.ssl.NonValidatingFactory \
+    java -jar your-app.jar
+```
+
 ## Logging
 
 Heroku expects applications to log to standard output, and provides its own log

--- a/dropwizard-heroku-db/src/test/java/com/loginbox/heroku/db/HerokuDataSourceFactoryTest.java
+++ b/dropwizard-heroku-db/src/test/java/com/loginbox/heroku/db/HerokuDataSourceFactoryTest.java
@@ -14,10 +14,12 @@ public class HerokuDataSourceFactoryTest {
     public void parsesDatabaseUrl() throws IOException, InterruptedException {
         HerokuDataSourceFactory f = run(
                 HerokuDataSourceFactory.class,
-                set("DATABASE_URL", "postgres://user:pass@db.example.com/database")
+                // Trailing %26 is an escaped & to verify that escaped characters are handled sanely.
+                // Spoiler alert: they aren't. Thanks, java.net.URI!
+                set("DATABASE_URL", "postgres://user:pass@db.example.com/database?query=%26")
         );
         assertThat(f.getDriverClass(), is("org.postgresql.Driver"));
-        assertThat(f.getUrl(), is("jdbc:postgresql://db.example.com/database"));
+        assertThat(f.getUrl(), is("jdbc:postgresql://db.example.com/database?query=&"));
         assertThat(f.getUser(), is("user"));
         assertThat(f.getPassword(), is("pass"));
     }


### PR DESCRIPTION
This was motivated by ticket #32, wherein someone asked for support for
accessing Heroku databases from outside of Heroku. That's a reasonable need,
but because of the way Heroku manages ephemeral-ish hosts like database
servers, there's no good default way to use SSL: it always needs to be told to
disregard cert validation, which I refuse to ship as the default configuration,
and writing a custom `SSLSocketFactory` which recognizes Heroku's specific
setup is an unending maintenance effort.

This implementation makes it the user's problem, and documents it. It's got
some ugly wrinkles around URL parameters with escapable characters in them, but
I think those will be rare-to-nonexistant in practice.