### PR TITLE
Upgraded to Dropwizard 0.9.1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@
 Using [Dropwizard](https://dropwizard.io/) on Heroku? This module takes care of
 some common cases automatically.
 
+## Dropwizard Versions
+
+Versions up to `0.2.0` are compatible with Dropwizard 0.8.x.
+Versions from `1.0.0` upward are compatible with Dropwizard 0.9.x.
+
 ## Installing
 
 All modules are hosted on Bintray's JCenter repository.

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ allprojects {
 
     dependencies {
         ext {
-            dropwizardVersion = '0.8.0'
+            dropwizardVersion = '0.9.1'
 
             // The following versions have to track dropwizardVersion but are not equal to it. You
             // can obtain the correct version numbers from the published dropwizard-parent POM.

--- a/dropwizard-heroku-db/src/test/java/com/loginbox/heroku/db/HerokuDataSourceFactoryTest.java
+++ b/dropwizard-heroku-db/src/test/java/com/loginbox/heroku/db/HerokuDataSourceFactoryTest.java
@@ -6,7 +6,7 @@ import java.io.IOException;
 
 import static com.loginbox.heroku.testing.env.EnvironmentHarness.*;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.nullValue;
 
 public class HerokuDataSourceFactoryTest {
@@ -18,10 +18,10 @@ public class HerokuDataSourceFactoryTest {
                 // Spoiler alert: they aren't. Thanks, java.net.URI!
                 set("DATABASE_URL", "postgres://user:pass@db.example.com/database?query=%26")
         );
-        assertThat(f.getDriverClass(), is("org.postgresql.Driver"));
-        assertThat(f.getUrl(), is("jdbc:postgresql://db.example.com/database?query=&"));
-        assertThat(f.getUser(), is("user"));
-        assertThat(f.getPassword(), is("pass"));
+        assertThat(f.getDriverClass(), equalTo("org.postgresql.Driver"));
+        assertThat(f.getUrl(), equalTo("jdbc:postgresql://db.example.com/database?query=&"));
+        assertThat(f.getUser(), equalTo("user"));
+        assertThat(f.getPassword(), equalTo("pass"));
     }
 
     @Test
@@ -30,10 +30,10 @@ public class HerokuDataSourceFactoryTest {
                 HerokuDataSourceFactory.class,
                 set("DATABASE_URL", "postgres://db.example.com/database")
         );
-        assertThat(f.getDriverClass(), is("org.postgresql.Driver"));
-        assertThat(f.getUrl(), is("jdbc:postgresql://db.example.com/database"));
-        assertThat(f.getUser(), is(nullValue()));
-        assertThat(f.getPassword(), is(""));
+        assertThat(f.getDriverClass(), equalTo("org.postgresql.Driver"));
+        assertThat(f.getUrl(), equalTo("jdbc:postgresql://db.example.com/database"));
+        assertThat(f.getUser(), nullValue());
+        assertThat(f.getPassword(), nullValue());
     }
 
     @Test
@@ -42,9 +42,9 @@ public class HerokuDataSourceFactoryTest {
                 HerokuDataSourceFactory.class,
                 unset("DATABASE_URL")
         );
-        assertThat(f.getDriverClass(), is("org.postgresql.Driver"));
-        assertThat(f.getUrl(), is(nullValue()));
-        assertThat(f.getUser(), is(nullValue()));
-        assertThat(f.getPassword(), is("")); // surprise!
+        assertThat(f.getDriverClass(), equalTo("org.postgresql.Driver"));
+        assertThat(f.getUrl(), nullValue());
+        assertThat(f.getUser(),nullValue());
+        assertThat(f.getPassword(), nullValue());
     }
 }

--- a/dropwizard-heroku-logging/src/main/java/com/loginbox/heroku/logging/HerokuLoggingFactory.java
+++ b/dropwizard-heroku-logging/src/main/java/com/loginbox/heroku/logging/HerokuLoggingFactory.java
@@ -3,6 +3,7 @@ package com.loginbox.heroku.logging;
 import com.google.common.collect.Lists;
 import io.dropwizard.logging.AppenderFactory;
 import io.dropwizard.logging.ConsoleAppenderFactory;
+import io.dropwizard.logging.DefaultLoggingFactory;
 import io.dropwizard.logging.LoggingFactory;
 
 import java.util.List;
@@ -15,7 +16,7 @@ import java.util.List;
  *
  * @see HerokuConsoleAppenderFactory
  */
-public class HerokuLoggingFactory extends LoggingFactory {
+public class HerokuLoggingFactory extends DefaultLoggingFactory {
     /**
      * Creates the default appenders for a Heroku application.
      *


### PR DESCRIPTION
* Dependency upgrades.
* Reflect upstream changes to DataSourceFactory's none-password behaviour in tests.
* Deal with the newly-interface-ified LoggingFactory by moving HerokuLoggingFactory to a child of DefaultLoggingFactory.
* Clarify version compatiblity in the README.

This change is not backwards-compatible.